### PR TITLE
chore: update dependencies to handle react 17, expo 44 and expo-file-system 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "url": "git+https://github.com/xcarpentier/rn-pdf-reader-js.git"
   },
   "peerDependencies": {
-    "expo": ">= 33.0.x < 41.0.x",
+    "expo": ">= 33.0.x < 44.x",
     "expo-constants": ">= 5.0.0 < 9.x",
-    "expo-file-system": ">= 5.0.0 < 9.x",
-    "react": "16.x",
+    "expo-file-system": ">= 5.0.0 < 13.x",
+    "react": ">= 16.x < 17.x",
     "react-native": "*",
     "react-native-webview": ">= 7.0.5 < 12.x"
   },


### PR DESCRIPTION
This PR update some peerDependencies to allow newest versions :

- react 17
- expo 44
- expo-file-system 13